### PR TITLE
remove duplicate restriction on for loops

### DIFF
--- a/src/configs/base.ts
+++ b/src/configs/base.ts
@@ -236,10 +236,6 @@ export const config: Linter.Config = {
     'no-restricted-syntax': [
       'error',
       {
-        selector: 'ForStatement',
-        message: 'Use a for..of loop instead. They are more concise.',
-      },
-      {
         selector: 'ForInStatement',
         message:
           'for..in loops iterate over the entire prototype chain, which is virtually never what you want.\n ' +


### PR DESCRIPTION
removes ForStatement from `no-restricted-syntax`

any cases caught by this are also caught by `@typescript-eslint/prefer-for-of` which is enabled on [line 161](https://github.com/SeedCompany/eslint-plugin/blob/master/src/configs/base.ts#L161) and makes this rule unnecessary

this rule also is a bit overly restrictive and flags simple for loops that can't be cleanly converted to for..of loops
e.g. `for (let i = 0; i < 100; i++) { console.log('hello world', i); }`